### PR TITLE
Fix for broken item tag

### DIFF
--- a/src/main/resources/data/forge/tags/items/ingots/uranium.json
+++ b/src/main/resources/data/forge/tags/items/ingots/uranium.json
@@ -1,6 +1,6 @@
 {
   "replace": false,
   "values": [
-    "indreb:refined_uranium"
+    "indreb:uranium_ingot"
   ]
 }


### PR DESCRIPTION
The old tag broke all entries to forge:ingots/uranium, due to indreb:refined_uranium not existing